### PR TITLE
Changed some links to current (existing) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An architecture for building themes based on carefully chosen syntax highlightin
 
 ## Documentation
 
-* [Styling Guidelines](https://github.com/chriskempson/base16/blob/master/styling.md)
-* [Builder Guidelines](https://github.com/chriskempson/base16/blob/master/builder.md)
-* [File Guidelines](https://github.com/chriskempson/base16/blob/master/file.md)
+* [Styling Guidelines](https://github.com/base16-project/base16/blob/master/styling.md)
+* [Builder Guidelines](https://github.com/base16-project/base16/blob/master/builder.md)
+* [File Guidelines](https://github.com/base16-project/base16/blob/master/file.md)
 
 ## Template Repositories
 


### PR DESCRIPTION
I compared what exists between the old repo and the new one. Those that have not been migrated yet can use a different formatting if desired.

This is especially important for the guidelines, which are undergoing changes.