### PR TITLE
Replace IRC references with Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,8 @@ If you've written a tool feel free to add it to the list below:
 
 ## Project Chat
 
-Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by the [#base16 channel](https://web.libera.chat/#base16) on [Libera Chat](https://libera.chat/) or the [bridged Matrix channel](https://matrix.to/#/#base16:libera.chat) to talk about it.
+Have something you want to discuss, but you're not sure it warrants an issue? Feel free to stop by
+[#tinted-theming:matrix.org](https://matrix.to/#/#tinted-theming:matrix.org) on [Matrix](https://matrix.org/).
 
 ## Credits
 


### PR DESCRIPTION
We've stopped using IRC and moved to `#tinted-theming:matrix.org` so updated docs to reflect this.