### PR TITLE
Various minor fixes to the 0.11.0-dev spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Add `variant` to scheme files
 - Add `scheme-variant` as a template variable
-- Add `is_{{ variant }}_variant` as a template variable
+- Add `scheme-slug-underscored` as a template variable
+- Add `scheme-is-{{ variant }}-variant` as a template variable
 - Add `filename` to the template config
 - Add `supported-systems` to template config
 - Add specific definition of our slugify method which works with Unicode

--- a/builder.md
+++ b/builder.md
@@ -117,9 +117,10 @@ A builder MUST provide the following variables to template files:
 - `scheme-author` - obtained from the `author` key of the scheme input
 - `scheme-description` - obtained from the `description` key of the scheme input
 - `scheme-slug` - obtained from the `slug` key of the scheme input (fallback value: a [slugified](#slugify) `scheme-name`)
+- `scheme-slug-underscored` - the `scheme-slug` template variable where dashes have been replaced with underscores
 - `scheme-system` - obtained from the `system` key of the scheme input
 - `scheme-variant` - obtained from the `variant` key of the scheme input
-- `is_{{variant}}_variant` - dynamic value built from the `variant` key of the scheme file. e.g. `variant: "light"` provides `is_light_variant` with a value of `true`.
+- `scheme-is-{{variant}}-variant` - dynamic value built from the `variant` key of the scheme file. e.g. `variant: "light"` provides `scheme-is-light-variant` with a value of `true`.
 
 Additionally, a builder MUST provide the following template variables for each defined palette token:
 


### PR DESCRIPTION
- Add `scheme-slug-underscored`

`scheme-slug-underscored` is being added because it is in use by at least one theme (it is already supported by the Go builder).

- Rename `is_{{ variant }}_variant` to `scheme-is-{{ variant }}-variant`

For consistency reasons, this variable should use dashes and be prefixed with `scheme`.