### PR TITLE
Fix missing Lowercase instruction in Slugify

### DIFF
--- a/builder.md
+++ b/builder.md
@@ -181,7 +181,7 @@ Slugify is simplest to implement in a number of passes:
 * Start with your input value, replacing any Unicode characters with their ASCII aproximations (as an example `é` would become `e`). On a technical level, this can be done by normalizing the string to the Unicode NFD form (which is the decomposed version), and then dropping any combining characters.
 * Lowercase all characters. (convert characters `A` to `Z`, to `a` to `z`.)
 * Replace spaces with the `-` character
-* Drop all non-alphanumeric and non-dash characters
+* Drop all characters that are neither alphanumeric nor dashes
 
 *Examples:*
 

--- a/builder.md
+++ b/builder.md
@@ -179,6 +179,7 @@ Additionally, a builder MUST provide the following template variables for each d
 Slugify is simplest to implement in a number of passes:
 
 * Start with your input value, replacing any Unicode characters with their ASCII aproximations (as an example `é` would become `e`). On a technical level, this can be done by normalizing the string to the Unicode NFD form (which is the decomposed version), and then dropping any combining characters.
+* Lowercase all characters. (convert characters `A` to `Z`, to `a` to `z`.)
 * Replace spaces with the `-` character
 * Drop all non-alphanumeric and non-dash characters
 


### PR DESCRIPTION
I'm currently working on updating the rust crate [`base16_color_scheme`] from the old [Base 16 spec](https://github.com/chriskempson/base16) to this one.
While implementing the slugify functionality I found that the instruction to lowercase the characters was missing.
This pr fixes it.

[`base16_color_scheme`]: https://github.com/titaniumtraveler/base16_color_scheme

Also the line `Drop all non-alphanumeric and non-dash characters` is a bit ambiguously worded and
something like `Drop all characters that are neither alphanumeric nor dashes` might be better. \
Though that is only a minor nitpick. (I added it as separate commit for convenience.)