### PR TITLE
Add auto-assign-issues github workflow

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,18 @@
+name: Auto assignment for issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: 'Auto-assign issue'
+        uses: pozil/auto-assign-issue@v2
+        with:
+          repo-token: ${{ secrets.BOT_ACCESS_TOKEN }}
+          teams: admins
+          numOfAssignee: 3


### PR DESCRIPTION
I use this workflow on [Tinty](https://github.com/tinted-theming/tinty) to auto assign people to newly created issues on the repo. Unfortunately we have to hard-code our usernames as assignees into the workflow but I spent some time trying to figure out how to get it to work by providing github org teams as assignees and having the the workflow assign one or many people to the issue (trying to mimic the functionality github has built into it with pull requests) but either I'm missing something obvious or it's not something that has been turned into a github action. I did find one action which claimed it could do it, but I wasn't able to get it to work. 

Anyway, this should at least have us notified when issues are created here.