### PR TITLE
fork base16-waybar into tinted-theming org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ When a repository is transferred to Tinted Theming, it then belongs to
 the Tinted Theming Github organization and community. The previous owner
 changes from being the owner of the repository to a maintainer of the
 repository. It is not mandatory to be a maintainer after transferring,
-but we recomment it.
+but we recommend it.
 
 Due to how Github deals with redirects, we recommend not re-creating a
 Github repository with the same URL after transferring since it will
@@ -59,7 +59,7 @@ The steps on your side are now complete. Next steps an admin will take
 will be:
 
 1. Add you to a relevant Github team
-1. Add the team as the maintainer of the newly transfered repository
+1. Add the team as the maintainer of the newly transferred repository
 1. If not already done, the primary branch will be set to `main`
 1. If the repository is a theme template repository, a PR will be
    created which sets up [@tinted-theming-bot] to run [builder] on on

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Other:
 * [Tmux](https://github.com/tinted-theming/base16-tmux) maintained by [mattdavis90](https://github.com/mattdavis90)
 * [Wob](https://github.com/tinted-theming/base16-wob) maintained by [h4-n1](https://github.com/h4-n1)
 * [Xresources](https://github.com/tinted-theming/base16-xresources) maintained by [DanManN](https://github.com/orgs/tinted-theming/people/DanManN), and [pinpox](https://github.com/orgs/tinted-theming/people/pinpox)
+* [Waybar](https://github.com/tinted-theming/base16-waybar) maintained by [laenzlinger](https://github.com/laenzlinger)
 
 ### Unofficial Templates
 
@@ -148,7 +149,6 @@ If you have a template you maintain, but don't want to submit it to this org, fe
 * [StumpWM](https://github.com/tpine/base16-stumpwm) maintained by [tpine](https://github.com/tpine)
 * [Sway](https://github.com/rkubosz/base16-sway) maintained by [rkubosz](https://github.com/rkubosz)
 * [Swaylock](https://git.michaelball.name/gid/base16-swaylock-template) maintained by [michael-ball](https://git.michaelball.name)
-* [Waybar](https://github.com/mnussbaum/base16-waybar) maintained by [mnussbaum](https://github.com/mnussbaum)
 * [Window Maker](https://github.com/d-torrance/base16-wmaker) maintained by [d-torrance](https://github.com/d-torrance)
 * [Wofi](https://sr.ht/~knezi/base16-wofi) maintained by [knezi](https://sr.ht/~knezi)
 * [Wofi colors file](https://github.com/agausmann/base16-wofi-colors) maintained by [agausmann](https://github.com/agausmann)

--- a/builder.md
+++ b/builder.md
@@ -5,7 +5,7 @@
 "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119).*
 
-This document describes the requirments and basic functionality of theme builders. Builders are generally designed for template maintainers' ease of use. Template maintainers SHOULD provide built versions of their template so the end user doesn't need to be aware of builders.
+This document describes the requirements and basic functionality of theme builders. Builders are generally designed for template maintainers' ease of use. Template maintainers SHOULD provide built versions of their template so the end user doesn't need to be aware of builders.
 
 ## Glossary
 
@@ -178,7 +178,7 @@ Additionally, a builder MUST provide the following template variables for each d
 
 Slugify is simplest to implement in a number of passes:
 
-* Start with your input value, replacing any Unicode characters with their ASCII aproximations (as an example `é` would become `e`). On a technical level, this can be done by normalizing the string to the Unicode NFD form (which is the decomposed version), and then dropping any combining characters.
+* Start with your input value, replacing any Unicode characters with their ASCII approximations (as an example `é` would become `e`). On a technical level, this can be done by normalizing the string to the Unicode NFD form (which is the decomposed version), and then dropping any combining characters.
 * Lowercase all characters. (convert characters `A` to `Z`, to `a` to `z`.)
 * Replace spaces with the `-` character
 * Drop all characters that are neither alphanumeric nor dashes


### PR DESCRIPTION
As described in https://github.com/tinted-theming/base16-waybar/issues/1 the base16-wabar was forked into the tinted-theming org to automatically maintain it.

As agreed with @JamyGolden  I would help to maintain this repo.

In addition, while reading the CONTRIBUTION.md I fixed some typos.