### PR TITLE
Add 16bit rgb variable support

### DIFF
--- a/builder.md
+++ b/builder.md
@@ -1,5 +1,5 @@
 # Builder Guidelines
-**Version 0.11.1**
+**Version 0.11.2**
 
 *The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be
@@ -170,6 +170,9 @@ Additionally, a builder MUST provide the following template variables for each d
 - `{{ token-name }}-rgb-r` - red component as a value between `0` and `255`. e.g "124"
 - `{{ token-name }}-rgb-g` - green component as a value between `0` and `255`. e.g "175"
 - `{{ token-name }}-rgb-b` - blue component as a value between `0` and `255` e.g "194"
+- `{{ token-name }}-rgb16-r` - 16 bit red component as a value between `0` and `65_535`. e.g "15000"
+- `{{ token-name }}-rgb16-g` - 16 bit green component as a value between `0` and `65_535`. e.g "30000"
+- `{{ token-name }}-rgb16-b` - 16 bit blue component as a value between `0` and `65_535` e.g "60000"
 - `{{ token-name }}-dec-r` - red component as a value between `0` and `1.0`. e.g "0.4863"
 - `{{ token-name }}-dec-g` - green component as a value between `0` and `1.0`. e.g "0.6863"
 - `{{ token-name }}-dec-b` - blue component as a value between `0` and `1.0`. e.g "0.7608"


### PR DESCRIPTION
I'm looking at building some Apple oascripts for [base16-iterm2](https://github.com/tinted-theming/base16-iterm2) to set the themes because right now people have to import the files individually within the iterm2 settings manually (I want to add support to hook up to tinty). In order to set these colors, 16bit color values are required as well as : https://iterm2.com/documentation-scripting.html. Eg: `set foreground color to {65535, 0, 0, 0}`

In attempting to do this I've come across the need for 16bit rgb support.