### PR TITLE
Specify bright colors first in the styling spec

### DIFF
--- a/styling.md
+++ b/styling.md
@@ -3,7 +3,7 @@ _The original version of this spec can be found at [chriskempson/base16](https:/
 ---
 
 # Base16 Styling Guidelines
-**Version 0.4.1**
+**Version 0.4.2**
 
 Base16 aims to group similar language constructs with a single color. For example, floats, ints, and doubles would belong to the same colour group. The colors for the default scheme were chosen to be easily separable, but scheme designers should pick whichever colours they desire, e.g. `base0B` (green by default) could be replaced with red. There are, however, some general guidelines below that stipulate which `base0B` should be used to highlight each construct when designing templates for editors.
 
@@ -37,13 +37,13 @@ We offer guidelines for both dark and light themes:
 | ![#](https://placehold.it/25/abb2bf/000000?text=+) | base05 | -        | Foreground               | Default Foreground, Caret, Delimiters, Operators |
 | ![#](https://placehold.it/25/e6e6e6/000000?text=+) | base06 | 7        | White                    | Light Foreground |
 | ![#](https://placehold.it/25/ffffff/000000?text=+) | base07 | 15       | Bright White             | The Lightest Foreground |
-| ![#](https://placehold.it/25/e06c75/000000?text=+) | base08 | 1 and 9  | Red and Bright Red       | Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted |
+| ![#](https://placehold.it/25/e06c75/000000?text=+) | base08 | 9  and 1 | Bright Red and Red       | Variables, XML Tags, Markup Link Text, Markup Lists, Diff Deleted |
 | ![#](https://placehold.it/25/d19a66/000000?text=+) | base09 | ~3       | (Orange)                 | Integers, Boolean, Constants, XML Attributes, Markup Link Url |
-| ![#](https://placehold.it/25/e5c07b/000000?text=+) | base0A | 3 and 11 | Yellow and Bright Yellow | Classes, Markup Bold, Search Text Background |
-| ![#](https://placehold.it/25/98c379/000000?text=+) | base0B | 2 and 10 | Green and Bright Green   | Strings, Inherited Class, Markup Code, Diff Inserted |
-| ![#](https://placehold.it/25/56b6c2/000000?text=+) | base0C | 6 and 14 | Cyan and Bright Cyan     | Support, Regular Expressions, Escape Characters, Markup Quotes |
-| ![#](https://placehold.it/25/61afef/000000?text=+) | base0D | 4 and 12 | Blue and Bright Blue     | Functions, Methods, Attribute IDs, Headings |
-| ![#](https://placehold.it/25/c678dd/000000?text=+) | base0E | 5 and 13 | Purple and Bright Purple | Keywords, Storage, Selector, Markup Italic, Diff Changed |
+| ![#](https://placehold.it/25/e5c07b/000000?text=+) | base0A | 11 and 3 | Bright Yellow and Yellow | Classes, Markup Bold, Search Text Background |
+| ![#](https://placehold.it/25/98c379/000000?text=+) | base0B | 10 and 2 | Bright Green and Green   | Strings, Inherited Class, Markup Code, Diff Inserted |
+| ![#](https://placehold.it/25/56b6c2/000000?text=+) | base0C | 14 and 6 | Bright Cyan and Cyan     | Support, Regular Expressions, Escape Characters, Markup Quotes |
+| ![#](https://placehold.it/25/61afef/000000?text=+) | base0D | 12 and 4 | Bright Blue and Blue     | Functions, Methods, Attribute IDs, Headings |
+| ![#](https://placehold.it/25/c678dd/000000?text=+) | base0E | 13 and 5 | Bright Purple and Purple | Keywords, Storage, Selector, Markup Italic, Diff Changed |
 | ![#](https://placehold.it/25/be5046/000000?text=+) | base0F | -        | (Dark Red or Brown)      | Deprecated, Opening/Closing Embedded Language Tags, e.g. `<?php ?>` |
 
 **Notes**:


### PR DESCRIPTION
This change doesn't practically change anything for base16, but affects scheme-systems that are a superset of base16. More details about this here: https://github.com/tinted-theming/base24/pull/30