### PR TITLE
Add Micro Editor to unofficial colorscheme templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ If you have a template you maintain, but don't want to submit it to this org, fe
 * [JOE](https://github.com/jjjordan/base16-joe) maintained by [jjjordan](https://github.com/jjjordan)
 * [Jetbrains IDE](https://github.com/ShiromMakkad/base16-jetbrains-ide) maintained by [ShiromMakkad](https://github.com/ShiromMakkad)
 * [Kakoune](https://github.com/leira/base16-kakoune) maintained by [leira](https://github.com/leira)
+* [Micro](https://github.com/w3dg/base16-micro) maintained by [w3dg](https://github.com/w3dg)
 * [MonoDevelop](https://github.com/netpyoung/base16-monodevelop) maintained by [netpyoung](https://github.com/netpyoung)
 * [QOwnNotes](https://github.com/themix-project/base16-template-qOwnNotes) maintained by [themix-project](https://github.com/themix-project)
 * [Scide](https://github.com/brunoro/base16-scide) maintained by [brunoro](https://github.com/brunoro)


### PR DESCRIPTION
Added base16 colorschemes for [micro](https://micro-editor.github.io/)