### PR TITLE
Add ci skip to commit message to avoid triggering CI checks

### DIFF
--- a/.github/workflows/shared-build-template-and-commit-themes.yml
+++ b/.github/workflows/shared-build-template-and-commit-themes.yml
@@ -35,7 +35,7 @@ jobs:
       - name: "Commit the changes, if any"
         uses: "stefanzweifel/git-auto-commit-action@be823a7e51f116fecebc222b8307716921375992" # 5.0.1
         with:
-          commit_message: "Update with the latest tinted-theming colorschemes"
+          commit_message: "Update with the latest tinted-theming colorschemes [skip ci]"
           branch: ${{ inputs.ref }}
           commit_user_name: "tinted-theming-bot"
           commit_user_email: "tintedtheming@proton.me"


### PR DESCRIPTION
With the added `[skip ci]` string to the commit message, template PRs can optionally check for that and skip CI checks.