### PR TITLE
Upgrade tinted8 builder and styling spec

### DIFF
--- a/specs/tinted8/builder.md
+++ b/specs/tinted8/builder.md
@@ -1,6 +1,6 @@
 # Tinted8 Builder Guidelines
 
-**Version 0.2.0-beta5** The latest version of this spec can be obtained from
+**Version 0.2.0-beta6** The latest version of this spec can be obtained from
 [tinted-theming/specs/tinted8/builder]
 
 ## Introduction
@@ -372,8 +372,10 @@ between variants.
 | ui.deprecated                            | brown-normal        | brown-normal         |
 | ui.accent                                | cyan-normal         | cyan-normal          |
 | ui.border                                | gray-dim            | gray-bright          |
-| ui.cursor.normal                         | white-normal        | black-normal         |
-| ui.cursor.muted                          | gray-bright         | gray-dim             |
+| ui.cursor.background.normal              | white-normal        | black-normal         |
+| ui.cursor.background.muted               | gray-bright         | gray-dim             |
+| ui.cursor.foreground.normal              | black-normal        | white-normal         |
+| ui.cursor.foreground.muted               | gray-dim            | gray-bright          |
 | ui.global.foreground.normal              | white-normal        | black-normal         |
 | ui.global.foreground.dark                | white-dim           | black-bright         |
 | ui.global.foreground.light               | white-bright        | black-dim            |

--- a/specs/tinted8/builder.md
+++ b/specs/tinted8/builder.md
@@ -1,6 +1,6 @@
 # Tinted8 Builder Guidelines
 
-**Version 0.2.0-beta6** The latest version of this spec can be obtained from
+**Version 0.2.0-beta7** The latest version of this spec can be obtained from
 [tinted-theming/specs/tinted8/builder]
 
 ## Introduction
@@ -370,8 +370,8 @@ between variants.
 | ui.global.background.dark                | black-dim           | white-bright         |
 | ui.global.background.light               | black-bright        | white-dim            |
 | ui.deprecated                            | brown-normal        | brown-normal         |
-| ui.accent                                | cyan-normal         | cyan-normal          |
-| ui.border                                | gray-dim            | gray-bright          |
+| ui.accent.normal                         | cyan-normal         | cyan-normal          |
+| ui.border.normal                         | gray-dim            | gray-bright          |
 | ui.cursor.background.normal              | white-normal        | black-normal         |
 | ui.cursor.background.muted               | gray-bright         | gray-dim             |
 | ui.cursor.foreground.normal              | black-normal        | white-normal         |
@@ -383,7 +383,7 @@ between variants.
 | ui.gutter.foreground                     | white-dim           | black-bright         |
 | ui.highlight.line.background             | gray-dim            | gray-bright          |
 | ui.highlight.line.foreground             | white-dim           | black-bright         |
-| ui.link                                  | cyan-normal         | cyan-normal          |
+| ui.link.normal                           | cyan-normal         | cyan-normal          |
 | ui.highlight.search.background           | black-bright        | white-dim            |
 | ui.highlight.search.foreground           | yellow-normal       | yellow-normal        |
 | ui.highlight.text.background             | gray-dim            | gray-bright          |

--- a/specs/tinted8/styling.md
+++ b/specs/tinted8/styling.md
@@ -1,6 +1,6 @@
 # Tinted8 Styling Guidelines
 
-**Version 0.2.0-beta4** The latest version of this spec can be obtained from
+**Version 0.2.0-beta5** The latest version of this spec can be obtained from
 [tinted-theming/specs/tinted8/styling](https://github.com/tinted-theming/home/blob/main/specs/tinted8/styling.md)
 
 ## Introduction
@@ -269,8 +269,10 @@ color code) value.
 | ui.deprecated                       | `<font color="red">Hello</font>` → `<font>` | Deprecated or outdated UI elements, signaling that they are no longer recommended. |
 | ui.accent                           | Focus rings / active border | Primary accent color for focus/active indications. |
 | ui.border                           | Panel/tab borders | Generic border/divider color. |
-| ui.cursor.normal                    | Editor caret | The text cursor color in editors. |
-| ui.cursor.muted                     | Muted/disabled editor caret | The muted/disabled text cursor color in editors. |
+| ui.cursor.background.normal         | Editor caret | The text cursor background color in editors. |
+| ui.cursor.background.muted          | Muted/disabled editor caret | The muted/disabled text cursor background color in editors. |
+| ui.cursor.foreground.normal         | Editor caret | The text cursor foreground color in editors. |
+| ui.cursor.foreground.muted          | Muted/disabled editor caret | The muted/disabled text foreground cursor color in editors. |
 | ui.global.foreground.normal         | Editor text → `"hello"` | General text in the user interface. |
 | ui.global.foreground.dark           | Sidebar file names → `filename.md` | Text in dark-themed UI areas or sections where a lighter font is needed. |
 | ui.global.foreground.light          | Active tab label → `main.js` | Light-colored text in the UI, often used in headings or highlighted sections. |

--- a/specs/tinted8/styling.md
+++ b/specs/tinted8/styling.md
@@ -1,6 +1,6 @@
 # Tinted8 Styling Guidelines
 
-**Version 0.2.0-beta5** The latest version of this spec can be obtained from
+**Version 0.2.0-beta6** The latest version of this spec can be obtained from
 [tinted-theming/specs/tinted8/styling](https://github.com/tinted-theming/home/blob/main/specs/tinted8/styling.md)
 
 ## Introduction
@@ -267,8 +267,8 @@ color code) value.
 | ui.global.background.dark           | Sidebar → background | Darker background areas, typically used for sidebars, footers, or other sections. |
 | ui.global.background.light          | Active tab → background | Lighter background areas, typically used for light modes or highlighting. |
 | ui.deprecated                       | `<font color="red">Hello</font>` → `<font>` | Deprecated or outdated UI elements, signaling that they are no longer recommended. |
-| ui.accent                           | Focus rings / active border | Primary accent color for focus/active indications. |
-| ui.border                           | Panel/tab borders | Generic border/divider color. |
+| ui.accent.normal                    | Focus rings / active border | Primary accent color for focus/active indications. |
+| ui.border.normal                    | Panel/tab borders | Generic border/divider color. |
 | ui.cursor.background.normal         | Editor caret | The text cursor background color in editors. |
 | ui.cursor.background.muted          | Muted/disabled editor caret | The muted/disabled text cursor background color in editors. |
 | ui.cursor.foreground.normal         | Editor caret | The text cursor foreground color in editors. |
@@ -288,7 +288,8 @@ color code) value.
 | ui.highlight.text.active-foreground | Active selection → text | Foreground when the selection is active/focused. |
 | ui.indent-guide.background          | Indent guides → background | Background color for indentation guide marks. |
 | ui.indent-guide.active-background   | Active indent guide → background | Background for the active/primary indent guide. |
-| ui.link                             | UI links | Link and interactive text color in UI chrome. |
+| ui.link.normal.background           | UI links | Link and interactive background color in UI chrome. |
+| ui.link.normal.foreground           | UI links | Link and interactive text color in UI chrome. |
 | ui.whitespace.foreground            | Invisible/whitespace guides → marks | Foreground for whitespace/invisible character markers. |
 | ui.selection.background             | Selected code → background | The background of selected items in the user interface (e.g., highlighted text or options). |
 | ui.selection.foreground             | Selected code → foreground | The foreground of selected items in the user interface (e.g., highlighted text or options). |


### PR DESCRIPTION
- builder 0.2.0-beta5 to 0.2.0-beta6
- styling 0.2.0-beta4 to 0.2.0-beta5

@carmiac adding a `background` and `foreground` option for the cursor since several themes I've been adding tinted8 support to have that as an option.