### PR TITLE
tinted8: Add `ui.chrome.*` values for styling sidebars, titlebars, etc

### DIFF
--- a/specs/tinted8/builder.md
+++ b/specs/tinted8/builder.md
@@ -1,6 +1,6 @@
 # Tinted8 Builder Guidelines
 
-**Version 0.2.0-beta7** The latest version of this spec can be obtained from
+**Version 0.2.0-beta8** The latest version of this spec can be obtained from
 [tinted-theming/specs/tinted8/builder]
 
 ## Introduction
@@ -367,11 +367,17 @@ between variants.
 | syntax.meta.embedded                     | white-normal        | black-normal         |
 | syntax.meta.object                       | orange-normal       | orange-normal        |
 | ui.global.background.normal              | black-normal        | white-normal         |
-| ui.global.background.dark                | black-dim           | white-bright         |
-| ui.global.background.light               | black-bright        | white-dim            |
+| ui.global.background.dark                | black-dim           | white-dim            |
+| ui.global.background.light               | black-bright        | white-bright         |
 | ui.deprecated                            | brown-normal        | brown-normal         |
 | ui.accent.normal                         | cyan-normal         | cyan-normal          |
 | ui.border.normal                         | gray-dim            | gray-bright          |
+| ui.chrome.background.normal              | black-bright        | white-dim            |
+| ui.chrome.background.dark                | black-dim           | gray-bright          |
+| ui.chrome.background.light               | gray-dim            | white-normal         |
+| ui.chrome.foreground.normal              | white-normal        | black-normal         |
+| ui.chrome.foreground.dark                | white-dim           | black-dim            |
+| ui.chrome.foreground.light               | white-bright        | black-bright         |
 | ui.cursor.background.normal              | white-normal        | black-normal         |
 | ui.cursor.background.muted               | gray-bright         | gray-dim             |
 | ui.cursor.foreground.normal              | black-normal        | white-normal         |

--- a/specs/tinted8/styling.md
+++ b/specs/tinted8/styling.md
@@ -1,6 +1,6 @@
 # Tinted8 Styling Guidelines
 
-**Version 0.2.0-beta6** The latest version of this spec can be obtained from
+**Version 0.2.0-beta7** The latest version of this spec can be obtained from
 [tinted-theming/specs/tinted8/styling](https://github.com/tinted-theming/home/blob/main/specs/tinted8/styling.md)
 
 ## Introduction
@@ -269,6 +269,12 @@ color code) value.
 | ui.deprecated                       | `<font color="red">Hello</font>` → `<font>` | Deprecated or outdated UI elements, signaling that they are no longer recommended. |
 | ui.accent.normal                    | Focus rings / active border | Primary accent color for focus/active indications. |
 | ui.border.normal                    | Panel/tab borders | Generic border/divider color. |
+| ui.chrome.background.normal         | Sidebar/tab bar/etc → background | The general background of app chrome surfaces (sidebars, tab bars, status bars, toolbars). |
+| ui.chrome.background.dark           | Sidebar/tab bar/etc → background | Can be used to highlight or mute areas. |
+| ui.chrome.background.light          | Sidebar/tab bar/etc → background | Can be used to highlight or mute areas. |
+| ui.chrome.foreground.normal         | Sidebar/tab bar/etc → text | General text/icon color in app chrome surfaces. |
+| ui.chrome.foreground.dark           | Sidebar/tab bar/etc → text | Could be used to highlight or mute areas. |
+| ui.chrome.foreground.light          | Sidebar/tab bar/etc → text | Could be used to highlight or mute areas. |
 | ui.cursor.background.normal         | Editor caret | The text cursor background color in editors. |
 | ui.cursor.background.muted          | Muted/disabled editor caret | The muted/disabled text cursor background color in editors. |
 | ui.cursor.foreground.normal         | Editor caret | The text cursor foreground color in editors. |


### PR DESCRIPTION
- Fix bug where `ui.global.background.dark` is `white-bright` and `ui.global.background.light` is `white-dim`
- Add `ui.chrome.*` properties to add more styling targets for sidebars, titlebars, etc